### PR TITLE
Fix ReadSignatureSection issue

### DIFF
--- a/vpkmod.cs
+++ b/vpkmod.cs
@@ -552,6 +552,9 @@ namespace SteamDatabase.ValvePak
                 return;
 
             var publicKeySize = Reader.ReadInt32();
+            if (SignatureSectionSize == 20 && publicKeySize == MAGIC)
+                return;
+
             PublicKey = Reader.ReadBytes(publicKeySize);
 
             var signatureSize = Reader.ReadInt32();


### PR DESCRIPTION
pulled from https://github.com/ValveResourceFormat/ValvePak/blob/0a3f51ee290a688464bd214120c823251c6e8121/ValvePak/ValvePak/Package.Read.cs#L309

The mod seems to still work without any other changes, other than [manually specifying](https://www.reddit.com/r/DotA2/comments/175fb62/nobling_dota_2023_how_to_use/) it...